### PR TITLE
Change name of instrumentation to slack_ruby_bot and revise installation info message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.2.0 (Next)
 
+* [#4](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/4): Revise New Relic log messages [@kstole](https://github.com/kstole).
 * Your contribution here.
 
 ### 0.1.1 (9/26/2017)

--- a/lib/newrelic-slack-ruby-bot/instrumentation.rb
+++ b/lib/newrelic-slack-ruby-bot/instrumentation.rb
@@ -1,5 +1,5 @@
 DependencyDetection.defer do
-  named :slack_ruby_bot_instrumentation
+  named :slack_ruby_bot
 
   depends_on do
     !::NewRelic::Agent.config[:disable_slack_ruby_bot]
@@ -10,7 +10,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info 'Installing New Relic supported SlackRubyBot instrumentation'
+    NewRelic::Agent.logger.info 'Installing SlackRubyBot instrumentation'
     instrument_call
   end
 


### PR DESCRIPTION
This is just a small modification for the New Relic log messages.
Errors show up as
```
ERROR : Error while installing slack_ruby_bot instrumentation:
```
instead of 
```
ERROR : Error while installing slack_ruby_bot_instrumentation instrumentation:
```