### PR TITLE
Support latest version of SlackRubyBot by applying instrumentation to message hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ### 0.2.0 (Next)
 
-* [#4](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/4): Revise New Relic log messages [@kstole](https://github.com/kstole).
+* [#4](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/4): Revise New Relic log messages - [@kstole](https://github.com/kstole).
+* [#5](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/5): Support latest version of SlackRubyBot by applying instrumentation to message hook - [@kstole](https://github.com/kstole).
 * Your contribution here.
 
 ### 0.1.1 (9/26/2017)
 
-* [#2](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/2): Lock slack-ruby-bot to latest compatible version (0.7.0) or lower [@kstole](https://github.com/kstole).
+* [#2](https://github.com/slack-ruby/newrelic-slack-ruby-bot/pull/2): Lock slack-ruby-bot to latest compatible version (0.7.0) or lower - [@kstole](https://github.com/kstole).
 
 ### 0.1.0 (12/27/2015)
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 3.4.0'
-gem 'rake', '< 11.0'
-gem 'rubocop', '0.35.1'
+group :test do
+  gem 'celluloid-io', require: %w(celluloid/current celluloid/io)
+  gem 'rake', '< 11.0'
+  gem 'rspec', '~> 3.4.0'
+  gem 'rubocop', '0.35.1'
+end

--- a/lib/newrelic-slack-ruby-bot/instrumentation.rb
+++ b/lib/newrelic-slack-ruby-bot/instrumentation.rb
@@ -15,17 +15,17 @@ DependencyDetection.defer do
   end
 
   def instrument_call
-    ::SlackRubyBot::Server.class_eval do
+    ::SlackRubyBot::Hooks::Message.class_eval do
       include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
       def message_with_new_relic(client, data)
-        perform_action_with_newrelic_trace(name: 'message', category: 'OtherTransaction/Slack') do
+        perform_action_with_newrelic_trace(name: 'call', category: 'OtherTransaction/Slack') do
           message_without_new_relic(client, data)
         end
       end
 
-      alias_method :message_without_new_relic, :message
-      alias_method :message, :message_with_new_relic
+      alias_method :message_without_new_relic, :call
+      alias_method :call, :message_with_new_relic
     end
   end
 end

--- a/newrelic-slack-ruby-bot.gemspec
+++ b/newrelic-slack-ruby-bot.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'NewRelic instrumentation for slack-ruby-bot.'
   s.add_dependency 'newrelic_rpm'
-  s.add_dependency 'slack-ruby-bot', '<= 0.7.0'
+  s.add_dependency 'slack-ruby-bot', '>= 0.8.0'
 end

--- a/spec/newrelic-slack-ruby-bot/instrumentation_spec.rb
+++ b/spec/newrelic-slack-ruby-bot/instrumentation_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper'
 
 describe NewRelic::Agent::Instrumentation do
+  subject { SlackRubyBot::Hooks::Message.new }
   let(:client) { SlackRubyBot::Client.new }
-  subject do
-    SlackRubyBot::Server.new
-  end
+
   it 'perform_action_with_newrelic_trace' do
     expect(subject)
       .to receive(:perform_action_with_newrelic_trace)
-      .with(hash_including(name: 'message'))
+      .with(hash_including(name: 'call', category: 'OtherTransaction/Slack'))
       .and_yield
 
-    subject.message(client, Hashie::Mash.new(message: 'message', text: 'hi'))
+    subject.call(client, Hashie::Mash.new(message: 'message', text: 'hi'))
   end
 end


### PR DESCRIPTION
For now, I think we should just apply the instrumentation to the built in message hook and then when the hooks mechanism in SlackRubyBot is updated to use the `on` method, we can look at changing this. @dblock thoughts?